### PR TITLE
Fix IndexedCorpus build with Boost 1.67.0

### DIFF
--- a/TreebankTools/IndexedCorpus/src/ActCorpusReader/ActCorpusReader.cpp
+++ b/TreebankTools/IndexedCorpus/src/ActCorpusReader/ActCorpusReader.cpp
@@ -117,7 +117,7 @@ vector<string> ActCorpusReader::entriesCorpus(path const &corpusPath)
 	if (!is_regular_file(indexPath))
 		throw runtime_error(string("Index file is not a regular file: ") + indexFilename);
 	
-	boost::shared_ptr<ifstream> indexStream(new ifstream(indexFilename.c_str()));
+	boost::shared_ptr<std::ifstream> indexStream(new std::ifstream(indexFilename.c_str()));
 	if (!*indexStream)
 		throw runtime_error(string("Could not open corpus index file for reading: ") + indexFilename);
 	
@@ -202,7 +202,7 @@ string ActCorpusReader::pathNameCorpus(path const &corpus,
 	if (!is_regular_file(indexPath))
 		throw runtime_error(string("Index file is not a regular file: ") + indexFilename);
 	
-	boost::shared_ptr<ifstream> indexStream(new ifstream(indexFilename.c_str()));
+	boost::shared_ptr<std::ifstream> indexStream(new std::ifstream(indexFilename.c_str()));
 	if (!*indexStream)
 		throw runtime_error(string("Could not open corpus index file for reading: ") + indexFilename);
 	
@@ -276,7 +276,7 @@ vector<unsigned char> ActCorpusReader::readFromCorpus(path const &corpus,
 	if (!is_regular_file(indexPath))
 		throw runtime_error(string("Index file is not a regular file: ") + indexFilename);
 
-	boost::shared_ptr<ifstream> indexStream(new ifstream(indexFilename.c_str()));
+	boost::shared_ptr<std::ifstream> indexStream(new std::ifstream(indexFilename.c_str()));
 	if (!*indexStream)
 		throw runtime_error(string("Could not open corpus index file for reading: ") + indexFilename);
 	

--- a/TreebankTools/IndexedCorpus/src/util/textfile/textfile.cpp
+++ b/TreebankTools/IndexedCorpus/src/util/textfile/textfile.cpp
@@ -8,7 +8,7 @@ vector<unsigned char> indexedcorpus::readFile(string const &filename)
 
 	vector<unsigned char> data;
 
-	ifstream dataStream(filename.c_str());
+	std::ifstream dataStream(filename.c_str());
 	if (!dataStream)
           throw runtime_error(string("File could not be read: '") + filename);
 


### PR DESCRIPTION
In recent boost versions, Boost's own `basic_ifstream` class has become
visible. This made uses of `ifstream` ambiguous. Resolve this by fully
qualifying those uses.