### PR TITLE
Compact corpora fix handling of file names with spaces

### DIFF
--- a/TreebankTools/IndexedCorpus/src/IndexedCorpusReader/IndexedCorpusReader.cpp
+++ b/TreebankTools/IndexedCorpus/src/IndexedCorpusReader/IndexedCorpusReader.cpp
@@ -11,14 +11,14 @@ IndexedCorpusReader::IndexedCorpusReader(IstreamPtr dataStream,
 		istringstream iss(line);
 		
 		string name;
-		iss >> name;
+		std::getline(iss, name, '\t');
 		
 		string offset64;
-		iss >> offset64;
+		std::getline(iss, offset64, '\t');
 		size_t offset = b64_decode<size_t>(offset64);
 
 		string size64;
-		iss >> size64;
+		std::getline(iss, size64);
 		size_t size = b64_decode<size_t>(size64);
 
 		IndexItemPtr item(new IndexItem(name, offset, size));


### PR DESCRIPTION
Compact corpus index entries were read using whitespace as a field
delimiter. This leads to the problem that in an entry with spaces, such
as

```
50 gr geroosterd wit en zwart sesamzaad.p.1.s.1.xml     A       1e
```

'gr' is interpreted as the offset and 'geroosterd' as the size. Since
these are also valid base64 strings, this leads to garbage offsets and
sizes. Fix this by only using tabs as delimiters.