### PR TITLE
Fix build of train_ngram_model on modern C++ compilers

### DIFF
--- a/Generation/fluency/CreateLM/Makefile
+++ b/Generation/fluency/CreateLM/Makefile
@@ -54,7 +54,7 @@ tag-tuples:
 	$(MAKE) $(DISK)/tag-unigrams.tpl $(DISK)/tag-bigrams.tpl $(DISK)/tag-trigrams.tpl
 
 train_ngram_model: train_ngram_model.cpp
-	g++ $(CXXFLAGS) -o $@ $< 
+	g++ $(CXXFLAGS) -std=c++11 -o $@ $<
 
 $(DISK)/unigrams: $(DISK)/corpus
 	$(CURRENT)/train_ngram_model $(DISK)/corpus 0 $(DISK)/unigrams $(DISK)/bigrams $(DISK)/trigrams

--- a/Generation/fluency/CreateLM/train_ngram_model.cpp
+++ b/Generation/fluency/CreateLM/train_ngram_model.cpp
@@ -3,12 +3,12 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
-#include <tr1/memory>
-#include <tr1/unordered_map>
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/replace.hpp>
@@ -16,7 +16,6 @@
 #include "train_ngram_model.h"
 
 using namespace std;
-using namespace std::tr1;
 
 typedef unordered_map<vector<string>, size_t, VectorHash<string> > NgramFreqs;
 typedef unordered_map<vector<string>, size_t, VectorHash<string> > NgramProbs;

--- a/Generation/fluency/CreateLM/train_ngram_model.h
+++ b/Generation/fluency/CreateLM/train_ngram_model.h
@@ -2,7 +2,7 @@
 #include <vector>
 #include <stdexcept>
 
-#include <tr1/functional>
+#include <functional>
 
 struct Lambdas
 {
@@ -19,7 +19,7 @@ struct VectorHash : public std::unary_function<std::vector<T>, size_t>
 {
   std::size_t operator()(std::vector<T> const &vec) const
   {
-    std::tr1::hash<T> tHash;
+    std::hash<T> tHash;
     size_t seed = 0;
 
     for (typename std::vector<T>::const_iterator iter = vec.begin();


### PR DESCRIPTION
train_ngram_model uses both the std and std::tr1 namespaces. Since C++ >= 11 has shared_ptr in the std namespace, uses of shared_ptr were ambiguous. This change makes train_ngram_model use std::shared_ptr. While at it, also replace uses of TR1's functional and unordered_map.