### PR TITLE
Replace use of boost::shared_ptr by std::shared_ptr

### DIFF
--- a/TreebankTools/IndexedCorpus/IndexedCorpus/DzIstream.hh
+++ b/TreebankTools/IndexedCorpus/IndexedCorpus/DzIstream.hh
@@ -2,9 +2,8 @@
 #define DZ_ISTREAM_HH
 
 #include <iostream>
+#include <memory>
 #include <string>
-
-#include <boost/smart_ptr/shared_ptr.hpp>
 
 #include "DzIstreamBuf.hh"
 
@@ -16,7 +15,7 @@ public:
 	DzIstream(char const *filename); // Let's stick to the standards... :/
 	virtual ~DzIstream() {}
 private:
-	boost::shared_ptr<DzIstreamBuf> d_streamBuf;
+	std::shared_ptr<DzIstreamBuf> d_streamBuf;
 };
 
 }

--- a/TreebankTools/IndexedCorpus/IndexedCorpus/DzOstream.hh
+++ b/TreebankTools/IndexedCorpus/IndexedCorpus/DzOstream.hh
@@ -2,9 +2,8 @@
 #define DZ_OSTREAM_HH
 
 #include <iostream>
+#include <memory>
 #include <string>
-
-#include <boost/smart_ptr/shared_ptr.hpp>
 
 #include "DzOstreamBuf.hh"
 
@@ -16,7 +15,7 @@ public:
 	DzOstream(char const *filename); // Let's stick to the standards... :/
 	virtual ~DzOstream() {}
 private:
-	boost::shared_ptr<DzOstreamBuf> d_streamBuf;
+	std::shared_ptr<DzOstreamBuf> d_streamBuf;
 };
 
 }

--- a/TreebankTools/IndexedCorpus/IndexedCorpus/IndexedCorpusReader.hh
+++ b/TreebankTools/IndexedCorpus/IndexedCorpus/IndexedCorpusReader.hh
@@ -3,11 +3,11 @@
 
 #include <iostream>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include <boost/config.hpp>
-#include <boost/smart_ptr/shared_ptr.hpp>
 
 #if defined(BOOST_HAS_THREADS)
 #include <boost/thread/thread.hpp>
@@ -27,12 +27,12 @@ struct IndexItem
 	size_t size;
 };
 
-typedef boost::shared_ptr<IndexItem> IndexItemPtr;
+typedef std::shared_ptr<IndexItem> IndexItemPtr;
 
 typedef std::map<std::string, IndexItemPtr> IndexMap;
 typedef std::vector<IndexItemPtr> IndexPtrVec;
 
-typedef boost::shared_ptr<std::istream> IstreamPtr;
+typedef std::shared_ptr<std::istream> IstreamPtr;
 
 class IndexedCorpusReader
 {

--- a/TreebankTools/IndexedCorpus/IndexedCorpus/IndexedCorpusWriter.hh
+++ b/TreebankTools/IndexedCorpus/IndexedCorpus/IndexedCorpusWriter.hh
@@ -2,9 +2,9 @@
 #define CORPUSWRITER_HH
 
 #include <iostream>
+#include <memory>
 
 #include <boost/config.hpp>
-#include <boost/smart_ptr/shared_ptr.hpp>
 
 #if defined(BOOST_HAS_THREADS)
 #include <boost/thread.hpp>
@@ -15,7 +15,7 @@
 namespace indexedcorpus
 {
 
-typedef boost::shared_ptr<std::ostream> ostreamPtr;
+typedef std::shared_ptr<std::ostream> ostreamPtr;
 
 class IndexedCorpusWriter
 {

--- a/TreebankTools/IndexedCorpus/Makefile
+++ b/TreebankTools/IndexedCorpus/Makefile
@@ -8,7 +8,7 @@ endif
 
 DYLIBLINKFLAGS=-fPIC -shared -lz
 WARN=-Wno-unused-local-typedefs
-CXXFLAGS=-O3 -Wall -I. -fPIC   $(WARN)
+CXXFLAGS=-O3 -Wall -std=c++11 -I. -fPIC   $(WARN)
 
 SOURCES=\
 	src/ActCorpusReader/ActCorpusReader.cpp \

--- a/TreebankTools/IndexedCorpus/python/indexedcorpus.cpp
+++ b/TreebankTools/IndexedCorpus/python/indexedcorpus.cpp
@@ -2,10 +2,9 @@
 
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
-
-#include <boost/smart_ptr/shared_ptr.hpp>
 
 #include <IndexedCorpus/ActCorpusReader.hh>
 #include <IndexedCorpus/DzIstream.hh>
@@ -45,7 +44,7 @@ static PyObject *IndexedCorpusReader_new(PyTypeObject *type, PyObject *args,
 	if (self == NULL)
 		return NULL;
 
-	boost::shared_ptr<std::istream> dataStream;
+	std::shared_ptr<std::istream> dataStream;
 	try {
 		dataStream.reset(new indexedcorpus::DzIstream(dataFilename));
 	} catch (std::exception &e) {
@@ -59,7 +58,7 @@ static PyObject *IndexedCorpusReader_new(PyTypeObject *type, PyObject *args,
 		return NULL;
 	}
 
-	boost::shared_ptr<std::istream> indexStream(new std::ifstream(indexFilename));
+	std::shared_ptr<std::istream> indexStream(new std::ifstream(indexFilename));
 	if (!*indexStream) {
 		raise_exception("Could not open index file!");
 		return NULL;
@@ -192,7 +191,7 @@ static PyObject *IndexedCorpusWriter_new(PyTypeObject *type, PyObject *args,
 	if (self == NULL)
 		return NULL;
 
-	boost::shared_ptr<std::ostream> dataStream;
+	std::shared_ptr<std::ostream> dataStream;
 	try {
 		dataStream.reset(new indexedcorpus::DzOstream(dataFilename));
 	} catch (std::exception &e) {
@@ -206,7 +205,7 @@ static PyObject *IndexedCorpusWriter_new(PyTypeObject *type, PyObject *args,
 		return NULL;
 	}
 
-	boost::shared_ptr<std::ostream> indexStream(new std::ofstream(indexFilename));
+	std::shared_ptr<std::ostream> indexStream(new std::ofstream(indexFilename));
 	if (!*indexStream) {
 		raise_exception("Could not open index file!");
 		return NULL;

--- a/TreebankTools/IndexedCorpus/src/ActCorpusReader/ActCorpusReader.cpp
+++ b/TreebankTools/IndexedCorpus/src/ActCorpusReader/ActCorpusReader.cpp
@@ -108,7 +108,7 @@ vector<string> ActCorpusReader::entriesCorpus(path const &corpusPath)
 	if (!is_regular_file(dataPath))
 		throw runtime_error(string("Data file is not a regular file: ") + dataFilename);
 	
-	boost::shared_ptr<istream> dataStream(new DzIstream(dataFilename.c_str()));
+	std::shared_ptr<istream> dataStream(new DzIstream(dataFilename.c_str()));
 	if (!*dataStream)
 		throw runtime_error(string("Could not open corpus data file for reading: ") + dataFilename);
 
@@ -117,7 +117,7 @@ vector<string> ActCorpusReader::entriesCorpus(path const &corpusPath)
 	if (!is_regular_file(indexPath))
 		throw runtime_error(string("Index file is not a regular file: ") + indexFilename);
 	
-	boost::shared_ptr<std::ifstream> indexStream(new std::ifstream(indexFilename.c_str()));
+	std::shared_ptr<std::ifstream> indexStream(new std::ifstream(indexFilename.c_str()));
 	if (!*indexStream)
 		throw runtime_error(string("Could not open corpus index file for reading: ") + indexFilename);
 	
@@ -193,7 +193,7 @@ string ActCorpusReader::pathNameCorpus(path const &corpus,
 	if (!is_regular_file(dataPath))
 		throw runtime_error(string("ActCorpusReader::pathNameCorpus: data file is not a regular file: ") + dataFilename);
 	
-	boost::shared_ptr<istream> dataStream(new DzIstream(dataFilename.c_str()));
+	std::shared_ptr<istream> dataStream(new DzIstream(dataFilename.c_str()));
 	if (!*dataStream)
 		throw runtime_error(string("Could not open corpus data file for reading: ") + dataFilename);
 
@@ -202,7 +202,7 @@ string ActCorpusReader::pathNameCorpus(path const &corpus,
 	if (!is_regular_file(indexPath))
 		throw runtime_error(string("Index file is not a regular file: ") + indexFilename);
 	
-	boost::shared_ptr<std::ifstream> indexStream(new std::ifstream(indexFilename.c_str()));
+	std::shared_ptr<std::ifstream> indexStream(new std::ifstream(indexFilename.c_str()));
 	if (!*indexStream)
 		throw runtime_error(string("Could not open corpus index file for reading: ") + indexFilename);
 	
@@ -267,7 +267,7 @@ vector<unsigned char> ActCorpusReader::readFromCorpus(path const &corpus,
 	if (!is_regular_file(dataPath))
 		throw runtime_error(string("Data file is not a regular file: ") + dataFilename);
 
-	boost::shared_ptr<istream> dataStream(new DzIstream(dataFilename.c_str()));
+	std::shared_ptr<istream> dataStream(new DzIstream(dataFilename.c_str()));
 	if (!*dataStream)
 		throw runtime_error(string("Could not open corpus data file for reading: ") + dataFilename);
 
@@ -276,7 +276,7 @@ vector<unsigned char> ActCorpusReader::readFromCorpus(path const &corpus,
 	if (!is_regular_file(indexPath))
 		throw runtime_error(string("Index file is not a regular file: ") + indexFilename);
 
-	boost::shared_ptr<std::ifstream> indexStream(new std::ifstream(indexFilename.c_str()));
+	std::shared_ptr<std::ifstream> indexStream(new std::ifstream(indexFilename.c_str()));
 	if (!*indexStream)
 		throw runtime_error(string("Could not open corpus index file for reading: ") + indexFilename);
 	

--- a/TreebankTools/IndexedCorpus/src/ActCorpusReader/ActCorpusReader.ih
+++ b/TreebankTools/IndexedCorpus/src/ActCorpusReader/ActCorpusReader.ih
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -15,7 +16,6 @@
 
 #include <boost/config.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/smart_ptr/shared_ptr.hpp>
 
 #if defined(BOOST_HAS_THREADS)
 #include <boost/thread.hpp>

--- a/TreebankTools/IndexedCorpus/test/test.cpp
+++ b/TreebankTools/IndexedCorpus/test/test.cpp
@@ -1,8 +1,8 @@
 #include <algorithm>
 #include <iterator>
+#include <memory>
 #include <sstream>
 #include <string>
-#include <boost/shared_ptr.hpp>
 
 #include <IndexedCorpus/ActCorpusReader.hh>
 #include <IndexedCorpus/DzOstream.hh>
@@ -15,7 +15,7 @@ using namespace indexedcorpus;
 void test_dzostream_crash()
 {
 	string dataFilename("/tmp/doesnotexist/asdf.data.dz");
-	boost::shared_ptr<indexedcorpus::DzOstream> dataStream(
+	std::shared_ptr<indexedcorpus::DzOstream> dataStream(
 	new indexedcorpus::DzOstream(dataFilename.c_str()));
 }
 

--- a/TreebankTools/miniact/Makefile
+++ b/TreebankTools/miniact/Makefile
@@ -6,7 +6,7 @@ include $(ALPINO_HOME)/Makefile.include
 endif
 endif
 
-CXXFLAGS=-Wall -pedantic -Wno-long-long -O3 -I. -I$(LIBCORPUS_PATH) 
+CXXFLAGS=-Wall -pedantic -std=c++11 -Wno-long-long -O3 -I. -I$(LIBCORPUS_PATH)
 
 SOURCES=ProgramOptions/ProgramOptions.cpp miniact.cpp
 OBJECTS=$(SOURCES:.cpp=.o)

--- a/TreebankTools/miniact/miniact.cpp
+++ b/TreebankTools/miniact/miniact.cpp
@@ -10,12 +10,11 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#include <boost/smart_ptr/shared_ptr.hpp>
 
 #include <glob.h>
 #include <libgen.h>
@@ -215,13 +214,13 @@ void compactDirs(vector<string> const &dirs)
 		
 
 		string dataFilename = dirName + ".data.dz";
-		boost::shared_ptr<indexedcorpus::DzOstream> dataStream(
+		std::shared_ptr<indexedcorpus::DzOstream> dataStream(
 			new indexedcorpus::DzOstream(dataFilename.c_str()));
 		if (!*dataStream)
 			throw runtime_error("Could not open corpus data file for writing!");
 
 		string indexFilename = dirName + ".index";
-		boost::shared_ptr<ofstream> indexStream(new ofstream(indexFilename.c_str()));
+		std::shared_ptr<ofstream> indexStream(new ofstream(indexFilename.c_str()));
 		if (!*indexStream)
 			throw runtime_error("Could not open corpus index file for writing!");
 		
@@ -246,12 +245,12 @@ void extractCorpus(vector<string> const &args, bool useStdout)
 
 	string dataFilename = corpusName + ".data.dz";
 	indexedcorpus::DzIstreamBuf dzStreamBuf(dataFilename.c_str());
-	boost::shared_ptr<istream> dataStream(new istream(&dzStreamBuf));
+	std::shared_ptr<istream> dataStream(new istream(&dzStreamBuf));
 	if (!*dataStream)
 		throw runtime_error("Could not open corpus data file for reading!");
 
 	string indexFilename = corpusName + ".index";
-	boost::shared_ptr<ifstream> indexStream(new ifstream(indexFilename.c_str()));
+	std::shared_ptr<ifstream> indexStream(new ifstream(indexFilename.c_str()));
 	if (!*indexStream)
 		throw runtime_error("Could not open corpus index file for reading!");
 
@@ -307,12 +306,12 @@ void listCorpora(vector<string> const &dirs)
 			dirName.erase(dirName.size() - 1);
 			
 		string dataFilename = dirName + ".data.dz";
-		boost::shared_ptr<ifstream> dataStream(new ifstream(dataFilename.c_str()));
+		std::shared_ptr<ifstream> dataStream(new ifstream(dataFilename.c_str()));
 		if (!*dataStream)
 			throw runtime_error("Could not open corpus data file for reading!");
 
 		string indexFilename = dirName + ".index";
-		boost::shared_ptr<ifstream> indexStream(new ifstream(indexFilename.c_str()));
+		std::shared_ptr<ifstream> indexStream(new ifstream(indexFilename.c_str()));
 		if (!*indexStream)
 			throw runtime_error("Could not open corpus index file for reading!");
 			


### PR DESCRIPTION
C++ has had a shared_ptr class since C++11, which is supported by all
modern compilers.