### PR TITLE
Fix Python build on GCC < 6

### DIFF
--- a/TreebankTools/IndexedCorpus/Makefile
+++ b/TreebankTools/IndexedCorpus/Makefile
@@ -89,9 +89,9 @@ python/indexedcorpus$(PYMODULEEXT): python/indexedcorpus.cpp libcorpus.a
 	rm -f python/indexedcorpus$(PYMODULEEXT)
 	rm -rf python/build
 	if [ -x ${PLATFORM} = "darwin" ] ; then \
-		( cd python ; ARCHFLAGS="-arch i386 -arch x86_64" BOOST_HOME=/usr python setup.py install --install-platlib=. ) \
+		( cd python ; CFLAGS="$(CXXFLAGS)" ARCHFLAGS="-arch i386 -arch x86_64" BOOST_HOME=/usr python setup.py install --install-platlib=. ) \
 	else \
-		( cd python ; BOOST_HOME=/usr python setup.py install --install-platlib=. ) \
+		( cd python ; CFLAGS="$(CXXFLAGS)" BOOST_HOME=/usr python setup.py install --install-platlib=. ) \
 	fi
 
 test/test: libcorpus.a test/test.cpp


### PR DESCRIPTION
GCC 6 uses gnu++14 for C++ by default. However to support GCC < 6,
we pass -std=c++11. Unfortunately, this flag was not passed to g++ when
compiling the Python module.

This change exposes CXXFLAGS to setup.py as CFLAGS (apparently,
distutils does not use CXXFLAGS?).